### PR TITLE
fix(windows): cast cbData to DWORD to unblock /WX builds (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2 - 2026-04-19
+
+### Fixed
+- Windows build failure under Flutter's default `/W4 /WX` settings: cast `size_t` expression to `DWORD` at `RegSetValueExW` `cbData` argument to silence C4267 narrowing warning promoted to error (#6)
+
 ## 1.0.1 - 2026-02-07
 
 ### Fixed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_device_platform_id
 description: "Flutter plugin for stable platform-scoped device IDs."
-version: 1.0.1
+version: 1.0.2
 
 repository: https://github.com/cyberprophet/flutter-device-unique-id
 

--- a/windows/flutter_device_platform_id_plugin.cpp
+++ b/windows/flutter_device_platform_id_plugin.cpp
@@ -126,7 +126,7 @@ bool FlutterDevicePlatformIdPlugin::SetUniqueIdInRegistry(const std::string& uni
 
   LONG result = RegSetValueExW(hkey, value_name, 0, REG_SZ,
                                reinterpret_cast<const BYTE*>(wide_id.c_str()),
-                               (wide_id.length() + 1) * sizeof(wchar_t));
+                               static_cast<DWORD>((wide_id.length() + 1) * sizeof(wchar_t)));
   RegCloseKey(hkey);
 
   return result == ERROR_SUCCESS;


### PR DESCRIPTION
## Summary
- Fixes #6: `flutter build windows` failing with C4267 size_t→DWORD narrowing at `RegSetValueExW` under Flutter's default `/W4 /WX`
- One-line `static_cast<DWORD>` around `(wide_id.length() + 1) * sizeof(wchar_t)`; device-ID strings never approach `DWORD_MAX`, so the cast is safe
- Bumps package to `1.0.2` and appends a Fixed entry to CHANGELOG

## Test plan
- [x] Windows plugin DLL compiles under Flutter's `/W4 /WX` (verified locally via `flutter build windows --debug` on the example; the plugin target builds — the remaining example-app registrant error is a pre-existing, unrelated issue on `main`)
- [ ] Reviewer verifies `flutter build windows --release` in a consumer project that pins `flutter_device_platform_id: ^1.0.2`
- [ ] Publish `1.0.2` to pub.dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)