### PR TITLE
fix(windows): use CApi pluginClass so generated registrant links (#6 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3 - 2026-04-19
+
+### Fixed
+- Windows plugin registration: set `windows.pluginClass` to `FlutterDevicePlatformIdPluginCApi` so Flutter's tooling emits the modern C API registrant (`..._plugin_c_api.h` / `...CApiRegisterWithRegistrar`) that matches the exported symbol. Previously, the generated `generated_plugin_registrant.cc` in consumer projects referenced a non-existent header and the example app failed to link.
+
 ## 1.0.2 - 2026-04-19
 
 ### Fixed

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_device_platform_id/flutter_device_platform_id_plugin.h>
+#include <flutter_device_platform_id/flutter_device_platform_id_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FlutterDevicePlatformIdPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterDevicePlatformIdPlugin"));
+  FlutterDevicePlatformIdPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterDevicePlatformIdPluginCApi"));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_device_platform_id
 description: "Flutter plugin for stable platform-scoped device IDs."
-version: 1.0.2
+version: 1.0.3
 
 repository: https://github.com/cyberprophet/flutter-device-unique-id
 
@@ -36,7 +36,7 @@ flutter:
       macos:
         pluginClass: FlutterDevicePlatformIdPlugin
       windows:
-        pluginClass: FlutterDevicePlatformIdPlugin
+        pluginClass: FlutterDevicePlatformIdPluginCApi
       web:
         pluginClass: FlutterDevicePlatformIdWeb
         fileName: flutter_device_platform_id_web.dart


### PR DESCRIPTION
## Summary
- Flutter's Windows plugin registrant template emits `#include <{name}/{pluginClass→snake}.h>` and `{pluginClass}RegisterWithRegistrar`. With `pluginClass: FlutterDevicePlatformIdPlugin` (legacy convention), the generator referenced `..._plugin.h` and a symbol that the plugin never exported, so every consumer's `generated_plugin_registrant.cc` failed to link.
- Modern scaffold encodes the C API suffix in `pluginClass` itself (e.g. `SamplePluginCApi`). Switching `windows.pluginClass` to `FlutterDevicePlatformIdPluginCApi` makes the regenerated registrant reference the real public header `flutter_device_platform_id_plugin_c_api.h` and call `FlutterDevicePlatformIdPluginCApiRegisterWithRegistrar`, which the plugin already exports.
- Bumps package to `1.0.3`, updates CHANGELOG, and commits the newly regenerated example registrant.

## Test plan
- [x] `flutter build windows --debug` on `example/` links cleanly — `flutter_device_platform_id_example.exe` produced
- [x] `flutter pub publish --dry-run` → 0 warnings
- [ ] Post-merge: publish `1.0.3` to pub.dev and tag `v1.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)