### PR TITLE
chore(example): refresh pubspec.lock for 1.0.3

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.3"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -146,18 +146,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -255,10 +255,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   vector_math:
     dependency: transitive
     description:
@@ -292,5 +292,5 @@ packages:
     source: hosted
     version: "3.0.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"


### PR DESCRIPTION
## Summary
- Regenerated after publishing `flutter_device_platform_id: 1.0.3` so the bundled example resolves to the current plugin version
- Transitive bumps from pub.dev: `characters 1.4.0 → 1.4.1`, `matcher 0.12.17 → 0.12.18`, `material_color_utilities 0.11.1 → 0.13.0`, `test_api 0.7.7 → 0.7.9`
- Dart SDK lower bound in lock: `3.8.0-0 → 3.9.0-0` (from the newer transitives)

## Test plan
- [x] `flutter build windows --debug` on `example/` linked cleanly with 1.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)